### PR TITLE
Fix a grid-related bug

### DIFF
--- a/src/components/Klavier.tsx
+++ b/src/components/Klavier.tsx
@@ -155,6 +155,7 @@ const Klavier = (props: KlavierProps) => {
 const getRootStyles = (width: React.CSSProperties['width'], height: React.CSSProperties['height']): CSSProperties => ({
   display: 'grid',
   alignItems: 'stretch',
+  gridAutoColumns: '1fr',
   gap: '1px',
   position: 'relative',
   WebkitUserSelect: 'none',


### PR DESCRIPTION
Not explicitly specifying `grid-auto-columns: `fr` in Safari causes uneven grid columns.