### PR TITLE
Remove version from repository's package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klavier",
   "description": "A lightweight, customizable, interactive piano library built with React.",
-  "version": "1.0.0",
+  "version": "0.0.0-semantic-release",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Versioning is handled by semantic-release when publishing and won't be updated in the repo: https://semantic-release.gitbook.io/semantic-release/support/faq#why-is-the-package.jsons-version-not-updated-in-my-repository