### PR TITLE
Remove whiteKeyAspectRatio

### DIFF
--- a/src/components/Key/Key.tsx
+++ b/src/components/Key/Key.tsx
@@ -1,71 +1,100 @@
 import React, { useMemo } from 'react';
 import { midiToNote } from 'lib/midi';
 import type { CustomKeyComponent, CustomLabelComponent, KeyColor, Keymap } from 'types';
-import { DEFAULT_BLACK_KEY_HEIGHT, DEFAULT_WHITE_KEY_ASPECT_RATIO, MIDI_NUMBER_C0 } from 'lib/constants';
+import { DEFAULT_BLACK_KEY_HEIGHT, MIDI_NUMBER_C0 } from 'lib/constants';
 import { defaultKeyComponents } from 'components/Key/defaultKeyComponents';
 
 type KeyProps = {
   midiNumber: number;
   firstNoteMidiNumber: number;
   active: boolean;
-  whiteKeyAspectRatio?: React.CSSProperties['aspectRatio'];
+  onMouseDown: React.MouseEventHandler;
+  onMouseUp: React.MouseEventHandler;
+  onMouseLeave: React.MouseEventHandler;
+  onMouseEnter: React.MouseEventHandler;
   blackKeyHeight?: React.CSSProperties['height'];
-  isFixedHeight: boolean;
+  height?: React.CSSProperties['height'];
   components?: {
     blackKey?: CustomKeyComponent;
     whiteKey?: CustomKeyComponent;
     label?: CustomLabelComponent;
   };
   keymap: Keymap | undefined;
-} & React.HTMLAttributes<HTMLDivElement>;
+};
 
 const Key = React.memo((props: KeyProps) => {
   const {
     active,
     midiNumber,
     firstNoteMidiNumber,
-    whiteKeyAspectRatio,
+    height,
     blackKeyHeight,
-    isFixedHeight,
     components,
     keymap,
-    ...htmlAttributes
+    onMouseDown,
+    onMouseUp,
+    onMouseEnter,
+    onMouseLeave,
   } = props;
   const note = midiToNote(midiNumber);
   const KeyComponent = getKeyComponent(components, note.keyColor);
-  const Label = components?.label;
   const style = useMemo(
-    () => getKeyStyles(midiNumber, firstNoteMidiNumber, isFixedHeight, whiteKeyAspectRatio, blackKeyHeight),
-    [midiNumber, firstNoteMidiNumber, isFixedHeight, whiteKeyAspectRatio, blackKeyHeight]
+    () => getKeyStyles(midiNumber, firstNoteMidiNumber, height, blackKeyHeight),
+    [midiNumber, firstNoteMidiNumber, height, blackKeyHeight]
   );
+  const Label = components?.label;
   const keyboardShortcut = useMemo(() => getKeyboardShortcut(midiNumber, keymap), [midiNumber, keymap]);
 
   return (
-    <div style={style} {...htmlAttributes} data-midi-number={midiNumber}>
+    <div
+      style={style}
+      data-midi-number={midiNumber}
+      onMouseDown={onMouseDown}
+      onMouseUp={onMouseUp}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
       <KeyComponent active={active} note={note} />
       {Label ? <Label active={active} note={note} keyboardShortcut={keyboardShortcut} midiC0={MIDI_NUMBER_C0} /> : null}
     </div>
   );
 });
 
+// The keyboard is laid out on a horizontal CSS grid.
+// Position represents a starting column: `grid-column-start` in CSS terms.
+// White keys span over 12 columns each, making the octave length 84 columns total.
+// Black keys span over 8 columns each, and are overlaid on top white keys.
+// Key positions (starting columns) of a single octave are calculated by hand to match a real piano keyboard as closely as possible.
+function getAbsoluteKeyPosition(midiNumber: number) {
+  const KEY_POSITIONS = [1, 8, 13, 22, 25, 37, 44, 49, 57, 61, 70, 73];
+  const OCTAVE_LENGTH_IN_COLUMNS = 84;
+  const { octave } = midiToNote(midiNumber);
+  return octave * OCTAVE_LENGTH_IN_COLUMNS + KEY_POSITIONS[midiNumber % KEY_POSITIONS.length];
+}
+
+function getKeyPosition(midiNumber: number, firstNoteMidiNumber: number) {
+  return getAbsoluteKeyPosition(midiNumber) - getAbsoluteKeyPosition(firstNoteMidiNumber) + 1;
+}
+
 function getKeyStyles(
   midiNumber: number,
   firstNoteMidiNumber: number,
-  isFixedHeight: boolean,
-  whiteKeyAspectRatio: React.CSSProperties['aspectRatio'] = DEFAULT_WHITE_KEY_ASPECT_RATIO,
+  height: React.CSSProperties['height'],
   blackKeyHeight: React.CSSProperties['height'] = DEFAULT_BLACK_KEY_HEIGHT
 ): React.CSSProperties {
   const WHITE_KEY_COLUMN_SPAN = 12;
   const BLACK_KEY_COLUMN_SPAN = 8;
+  const WHITE_KEY_ASPECT_RATIO = '24 / 150';
   const position = getKeyPosition(midiNumber, firstNoteMidiNumber);
   const { keyColor } = midiToNote(midiNumber);
+
   switch (keyColor) {
     case 'white':
       return {
         position: 'relative',
         boxSizing: 'border-box',
         gridRow: '1 / span 1',
-        aspectRatio: isFixedHeight ? undefined : whiteKeyAspectRatio,
+        aspectRatio: height === undefined ? WHITE_KEY_ASPECT_RATIO : undefined,
         gridColumn: `${position} / span ${WHITE_KEY_COLUMN_SPAN}`,
       };
     case 'black':
@@ -86,22 +115,6 @@ function getKeyComponent(components: KeyProps['components'], color: KeyColor) {
 
 function getKeyboardShortcut(midiNumber: number, keymap: KeyProps['keymap']) {
   return keymap?.find((item) => item.midiNumber === midiNumber)?.key;
-}
-
-// The keyboard is laid out on a horizontal CSS grid.
-// Position represents a starting column: `grid-column-start` in CSS terms.
-// White keys span over 12 columns each, making the octave length 84 columns total.
-// Black keys span over 8 columns each, and are overlaid on top white keys.
-// Key positions (starting columns) of a single octave are calculated by hand to match a real piano keyboard as closely as possible.
-function getAbsoluteKeyPosition(midiNumber: number) {
-  const KEY_POSITIONS = [1, 8, 13, 22, 25, 37, 44, 49, 57, 61, 70, 73];
-  const OCTAVE_LENGTH_IN_COLUMNS = 84;
-  const { octave } = midiToNote(midiNumber);
-  return octave * OCTAVE_LENGTH_IN_COLUMNS + KEY_POSITIONS[midiNumber % KEY_POSITIONS.length];
-}
-
-function getKeyPosition(midiNumber: number, firstNoteMidiNumber: number) {
-  return getAbsoluteKeyPosition(midiNumber) - getAbsoluteKeyPosition(firstNoteMidiNumber) + 1;
 }
 
 export type { KeyProps };

--- a/src/components/Klavier.tsx
+++ b/src/components/Klavier.tsx
@@ -68,12 +68,6 @@ interface KlavierProps {
   height?: React.CSSProperties['height'];
 
   /**
-   * Aspect ratio of the white key in CSS format. Ignored when `height` is specified.
-   * @defaultValue '23 / 150'
-   */
-  whiteKeyAspectRatio?: React.CSSProperties['aspectRatio'];
-
-  /**
    * Height of the black key. Allows tweaking the appearance of black keys in relation to white keys.
    * @defaultValue '67.5%'
    */
@@ -108,7 +102,6 @@ const Klavier = (props: KlavierProps) => {
     keyMap = DEFAULT_KEYMAP,
     width,
     height,
-    whiteKeyAspectRatio,
     blackKeyHeight,
     components,
   } = props;
@@ -150,8 +143,7 @@ const Klavier = (props: KlavierProps) => {
           onMouseUp={handleMouseEvents}
           onMouseLeave={handleMouseEvents}
           onMouseEnter={handleMouseEvents}
-          isFixedHeight={height !== undefined}
-          whiteKeyAspectRatio={whiteKeyAspectRatio}
+          height={height}
           blackKeyHeight={blackKeyHeight}
           components={components}
           keymap={keyMap}

--- a/src/interactivity/useMouse.ts
+++ b/src/interactivity/useMouse.ts
@@ -22,6 +22,10 @@ export function useMouse(props: UseMouseProps) {
 
   const handleMouseEvents = useCallback(
     (event: React.MouseEvent) => {
+      if (!enabled) {
+        return;
+      }
+
       const dataNumber = event.currentTarget.getAttribute('data-midi-number');
       if (!dataNumber) {
         return;
@@ -47,12 +51,8 @@ export function useMouse(props: UseMouseProps) {
           break;
       }
     },
-    [handleGlobalMouseUp, playNote, stopNote, setMouseDown]
+    [enabled, handleGlobalMouseUp, playNote, stopNote, setMouseDown]
   );
-
-  if (!enabled) {
-    return;
-  }
 
   return handleMouseEvents;
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,5 +8,4 @@ export const BLACK_KEY_MIDI_NUMBERS = [
 ];
 
 export const DEFAULT_NOTE_RANGE: [number, number] = [21, 108];
-export const DEFAULT_WHITE_KEY_ASPECT_RATIO = '24 / 150';
 export const DEFAULT_BLACK_KEY_HEIGHT = '67.5%';


### PR DESCRIPTION
Remove whiteKeyAspectRatio option. Users can instead use `aspect-ratio` on the parent.